### PR TITLE
Add a verify-pyc command to perform QA checks for .pyc files

### DIFF
--- a/gpep517/qa.py
+++ b/gpep517/qa.py
@@ -1,0 +1,57 @@
+import importlib.util
+import os
+import os.path
+
+
+def qa_verify_pyc(destdir, sitedirs):
+    missing_pyc = []
+    older_pyc = []
+    invalid_pyc = []
+    stray_pyc = []
+
+    for sitedir in sitedirs:
+        top_path = destdir + sitedir
+        if not os.path.isdir(top_path):
+            continue
+
+        py_files = set()
+        pyc_files = set()
+
+        for path, dirs, files in os.walk(top_path):
+            for fn in files:
+                if fn.endswith(".py"):
+                    py_files.add(os.path.join(path, fn))
+                elif fn.endswith((".pyc", ".pyo")):
+                    pyc_files.add(os.path.join(path, fn))
+
+        for py in py_files:
+            for opt in ("", 1, 2):
+                pyc = importlib.util.cache_from_source(py, optimization=opt)
+                # 1. check for missing .pyc files
+                if pyc not in pyc_files:
+                    missing_pyc.append((pyc, py))
+                    continue
+
+                pyc_files.remove(pyc)
+                # 2. check magic
+                with open(pyc, "rb") as f:
+                    magic = f.read(4)
+                    if magic != importlib.util.MAGIC_NUMBER:
+                        invalid_pyc.append((pyc, py))
+                        continue
+
+                # 3. check mtime
+                py_st = os.stat(py)
+                pyc_st = os.stat(pyc)
+                if pyc_st.st_mtime < py_st.st_mtime:
+                    older_pyc.append((pyc, py))
+
+        # 4. any remaining .pyc files are stray
+        stray_pyc.extend((pyc,) for pyc in pyc_files)
+
+    return {
+        "missing": missing_pyc,
+        "invalid": invalid_pyc,
+        "older": older_pyc,
+        "stray": stray_pyc,
+    }


### PR DESCRIPTION
Example output (for fabricated image):

```
$ python -m gpep517 verify-pyc --destdir /tmp/portage/dev-python/flit_core-3.7.1/image/
missing:/usr/lib/python3.11/site-packages/flit_core/tests/samples/package1/subpkg2/__init__.py:/usr/lib/python3.11/site-packages/flit_core/tests/samples/package1/subpkg2/__pycache__/__init__.cpython-311.pyc
missing:/usr/lib/python3.11/site-packages/flit_core/tests/samples/imported_version/package1/__init__.py:/usr/lib/python3.11/site-packages/flit_core/tests/samples/imported_version/package1/__pycache__/__init__.cpython-311.opt-1.pyc
invalid:/usr/lib/python3.11/site-packages/flit_core/config.py:/usr/lib/python3.11/site-packages/flit_core/__pycache__/config.cpython-311.opt-2.pyc
older:/usr/lib/python3.11/site-packages/flit_core/wheel.py:/usr/lib/python3.11/site-packages/flit_core/__pycache__/wheel.cpython-311.pyc
older:/usr/lib/python3.11/site-packages/flit_core/wheel.py:/usr/lib/python3.11/site-packages/flit_core/__pycache__/wheel.cpython-311.opt-1.pyc
older:/usr/lib/python3.11/site-packages/flit_core/wheel.py:/usr/lib/python3.11/site-packages/flit_core/__pycache__/wheel.cpython-311.opt-2.pyc
stray:/usr/lib/python3.11/site-packages/flit_core/tests/samples/foo.pyc
```